### PR TITLE
Update github-deploy-actions.yml

### DIFF
--- a/.github/workflows/github-deploy-actions.yml
+++ b/.github/workflows/github-deploy-actions.yml
@@ -27,6 +27,6 @@ jobs:
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          deploy_key: ${{ secrets.ACTIONS_KEY }}
           publish_dir: ./dist
           publish_branch: gh-pages


### PR DESCRIPTION
Updated actions to use ed25519 based deploy key for gh-pages push.